### PR TITLE
feat: add type representation in vm package

### DIFF
--- a/parser/decl.go
+++ b/parser/decl.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"go/constant"
 	"go/token"
-	"reflect"
 	"strings"
 
 	"github.com/mvertes/parscan/lang"
 	"github.com/mvertes/parscan/scanner"
+	"github.com/mvertes/parscan/vm"
 )
 
-var nilValue = reflect.ValueOf(nil)
+var nilValue = vm.ValueOf(nil)
 
 func (p *Parser) ParseConst(in Tokens) (out Tokens, err error) {
 	if len(in) < 2 {
@@ -78,7 +78,7 @@ func (p *Parser) parseConstLine(in Tokens) (out Tokens, err error) {
 			kind:  symConst,
 			index: unsetAddr,
 			cval:  cval,
-			value: reflect.ValueOf(constValue(cval)),
+			value: vm.ValueOf(constValue(cval)),
 			local: p.funcScope != "",
 			used:  true,
 		}
@@ -225,7 +225,7 @@ func (p *Parser) parseTypeLine(in Tokens) (out Tokens, err error) {
 	if err != nil {
 		return out, err
 	}
-	p.addSym(unsetAddr, in[0].Str, reflect.New(typ).Elem(), symType, typ, p.funcScope != "")
+	p.addSym(unsetAddr, in[0].Str, vm.NewValue(typ), symType, typ, p.funcScope != "")
 	return out, err
 }
 

--- a/parser/interpreter.go
+++ b/parser/interpreter.go
@@ -41,7 +41,7 @@ func (i *Interpreter) Eval(src string) (res any, err error) {
 		i.PrintCode()
 	}
 	err = i.Run()
-	return i.Top(), err
+	return i.Top().Data, err
 }
 
 func max(a, b int) int {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -420,8 +420,8 @@ func (p *Parser) ParseReturn(in Tokens) (out Tokens, err error) {
 	// TODO: the function symbol should be already present in the parser context.
 	// otherwise no way to handle anonymous func.
 	s := p.function
-	in[0].Beg = s.Type.NumOut()
-	in[0].End = s.Type.NumIn()
+	in[0].Beg = s.Type.Rtype.NumOut()
+	in[0].End = s.Type.Rtype.NumIn()
 	out = append(out, in[0])
 	return out, err
 }

--- a/parser/symbol.go
+++ b/parser/symbol.go
@@ -3,8 +3,9 @@ package parser
 import (
 	"fmt"
 	"go/constant"
-	"reflect"
 	"strings"
+
+	"github.com/mvertes/parscan/vm"
 )
 
 type symKind int
@@ -23,25 +24,25 @@ const unsetAddr = -65535
 type symbol struct {
 	kind  symKind
 	index int            // address of symbol in frame
-	value reflect.Value  //
+	Type  *vm.Type       //
+	value vm.Value       //
 	cval  constant.Value //
-	Type  reflect.Type   //
 	local bool           // if true address is relative to local frame, otherwise global
 	used  bool           //
 }
 
-func symtype(s *symbol) reflect.Type {
+func symtype(s *symbol) *vm.Type {
 	if s.Type != nil {
 		return s.Type
 	}
-	return reflect.TypeOf(s.value)
+	return vm.TypeOf(s.value)
 }
 
-func (p *Parser) AddSym(i int, name string, v reflect.Value) {
+func (p *Parser) AddSym(i int, name string, v vm.Value) {
 	p.addSym(i, name, v, symValue, nil, false)
 }
 
-func (p *Parser) addSym(i int, name string, v reflect.Value, k symKind, t reflect.Type, local bool) {
+func (p *Parser) addSym(i int, name string, v vm.Value, k symKind, t *vm.Type, local bool) {
 	name = strings.TrimPrefix(name, "/")
 	p.symbols[name] = &symbol{kind: k, index: i, local: local, value: v, Type: t}
 }
@@ -66,17 +67,17 @@ func (p *Parser) getSym(name, scope string) (sym *symbol, sc string, ok bool) {
 
 func initUniverse() map[string]*symbol {
 	return map[string]*symbol{
-		"any":    {kind: symType, index: unsetAddr, Type: reflect.TypeOf((*any)(nil)).Elem()},
-		"bool":   {kind: symType, index: unsetAddr, Type: reflect.TypeOf((*bool)(nil)).Elem()},
-		"error":  {kind: symType, index: unsetAddr, Type: reflect.TypeOf((*error)(nil)).Elem()},
-		"int":    {kind: symType, index: unsetAddr, Type: reflect.TypeOf((*int)(nil)).Elem()},
-		"string": {kind: symType, index: unsetAddr, Type: reflect.TypeOf((*string)(nil)).Elem()},
+		"any":    {kind: symType, index: unsetAddr, Type: vm.TypeOf((*any)(nil)).Elem()},
+		"bool":   {kind: symType, index: unsetAddr, Type: vm.TypeOf((*bool)(nil)).Elem()},
+		"error":  {kind: symType, index: unsetAddr, Type: vm.TypeOf((*error)(nil)).Elem()},
+		"int":    {kind: symType, index: unsetAddr, Type: vm.TypeOf((*int)(nil)).Elem()},
+		"string": {kind: symType, index: unsetAddr, Type: vm.TypeOf((*string)(nil)).Elem()},
 
 		"nil":   {index: unsetAddr},
 		"iota":  {kind: symConst, index: unsetAddr},
-		"true":  {index: unsetAddr, value: reflect.ValueOf(true), Type: reflect.TypeOf(true)},
-		"false": {index: unsetAddr, value: reflect.ValueOf(false), Type: reflect.TypeOf(false)},
+		"true":  {index: unsetAddr, value: vm.ValueOf(true), Type: vm.TypeOf(true)},
+		"false": {index: unsetAddr, value: vm.ValueOf(false), Type: vm.TypeOf(false)},
 
-		"println": {index: unsetAddr, value: reflect.ValueOf(func(v ...any) { fmt.Println(v...) })},
+		"println": {index: unsetAddr, value: vm.ValueOf(func(v ...any) { fmt.Println(v...) })},
 	}
 }

--- a/vm/type.go
+++ b/vm/type.go
@@ -1,0 +1,74 @@
+package vm
+
+import "reflect"
+
+// Runtime type and value representations (based on reflect).
+
+// Type is the representation of a runtime type.
+type Type struct {
+	Name  string
+	Rtype reflect.Type
+}
+
+func (t *Type) Elem() *Type {
+	return &Type{Rtype: t.Rtype.Elem()}
+}
+
+func (t *Type) Out(i int) *Type {
+	return &Type{Rtype: t.Rtype.Out(i)}
+}
+
+// Value is the representation of a runtime value.
+type Value struct {
+	Type *Type
+	Data reflect.Value
+}
+
+// NewValue returns an addressable zero value for the specified type.
+func NewValue(typ *Type) Value {
+	return Value{Type: typ, Data: reflect.New(typ.Rtype).Elem()}
+}
+
+// TypeOf returns the runtime type of v.
+func TypeOf(v any) *Type {
+	t := reflect.TypeOf(v)
+	return &Type{Name: t.Name(), Rtype: t}
+}
+
+// ValueOf returns the runtime value of v.
+func ValueOf(v any) Value {
+	return Value{Data: reflect.ValueOf(v)}
+}
+
+func PointerTo(t *Type) *Type {
+	return &Type{Rtype: reflect.PointerTo(t.Rtype)}
+}
+
+func ArrayOf(size int, t *Type) *Type {
+	return &Type{Rtype: reflect.ArrayOf(size, t.Rtype)}
+}
+
+func SliceOf(t *Type) *Type {
+	return &Type{Rtype: reflect.SliceOf(t.Rtype)}
+}
+
+func FuncOf(arg, ret []*Type, variadic bool) *Type {
+	a := make([]reflect.Type, len(arg))
+	for i, e := range arg {
+		a[i] = e.Rtype
+	}
+	r := make([]reflect.Type, len(ret))
+	for i, e := range ret {
+		r[i] = e.Rtype
+	}
+	return &Type{Rtype: reflect.FuncOf(a, r, variadic)}
+}
+
+func StructOf(fields []*Type) *Type {
+	rf := make([]reflect.StructField, len(fields))
+	for i, f := range fields {
+		rf[i].Name = "X" + f.Name
+		rf[i].Type = f.Rtype
+	}
+	return &Type{Rtype: reflect.StructOf(rf)}
+}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"testing"
 )
 
@@ -50,11 +49,10 @@ func BenchmarkVM(b *testing.B) {
 }
 
 var tests = []struct {
-	//sym        []any     // initial memory values
-	sym        []reflect.Value // initial memory values
-	code       [][]int64       // bytecode to execute
-	start, end int             //
-	mem        string          // expected memory content
+	sym        []Value   // initial memory values
+	code       [][]int64 // bytecode to execute
+	start, end int       //
+	mem        string    // expected memory content
 }{{ // #00 -- A simple addition.
 	code: [][]int64{
 		{0, Push, 1},
@@ -64,7 +62,7 @@ var tests = []struct {
 	},
 	start: 0, end: 1, mem: "[3]",
 }, { // #01 -- Calling a function defined outside the VM.
-	sym: []reflect.Value{reflect.ValueOf(fmt.Println), reflect.ValueOf("Hello")},
+	sym: []Value{ValueOf(fmt.Println), ValueOf("Hello")},
 	code: [][]int64{
 		{0, Dup, 0},
 		{0, CallX, 1},


### PR DESCRIPTION
Type and Value types in vm package are now used in place of reflect.Type and reflect.Value. It allows to remove the dependency on reflect for parser and compiler packages.

The main purpose of Type is to provide a solution to implement recursive structs, named types, interfaces and methods, despite the limitations of Go reflect. The goal is to provide the thinnest layer around reflect.