### PR TITLE
feat: initial and partial support of composite expressions

### DIFF
--- a/lang/token.go
+++ b/lang/token.go
@@ -111,6 +111,7 @@ const (
 	// Internal virtual machine tokens (no corresponding keyword).
 	Call
 	CallX
+	Composite
 	EqualSet
 	Grow
 	Index

--- a/lang/token_string.go
+++ b/lang/token_string.go
@@ -93,19 +93,20 @@ func _() {
 	_ = x[Var-82]
 	_ = x[Call-83]
 	_ = x[CallX-84]
-	_ = x[EqualSet-85]
-	_ = x[Grow-86]
-	_ = x[Index-87]
-	_ = x[JumpFalse-88]
-	_ = x[JumpSetFalse-89]
-	_ = x[JumpSetTrue-90]
-	_ = x[Label-91]
-	_ = x[New-92]
+	_ = x[Composite-85]
+	_ = x[EqualSet-86]
+	_ = x[Grow-87]
+	_ = x[Index-88]
+	_ = x[JumpFalse-89]
+	_ = x[JumpSetFalse-90]
+	_ = x[JumpSetTrue-91]
+	_ = x[Label-92]
+	_ = x[New-93]
 }
 
-const _Token_name = "IllegalCommentIdentCharFloatImagIntStringAddSubMulQuoRemAndOrXorShlShrAndNotPeriodEqualGreaterGreaterEqualLandLessLessEqualLorNotEqualDefineAssignAddAssignSubAssignMulAssignQuoAssignRemAssignAndAssignOrAssignXorAssignShlAssignShrAssignAndNotAssignIncDecPlusMinusAddrDerefBitCompArrowEllipsisNotTildeCommaSemicolonColonParenBlockBracketBlockBraceBlockBreakCaseChanConstContinueDefaultDeferElseFallthroughForFuncGoGotoIfImportInterfaceMapPackageRangeReturnSelectStructSwitchTypeVarCallCallXEqualSetGrowIndexJumpFalseJumpSetFalseJumpSetTrueLabelNew"
+const _Token_name = "IllegalCommentIdentCharFloatImagIntStringAddSubMulQuoRemAndOrXorShlShrAndNotPeriodEqualGreaterGreaterEqualLandLessLessEqualLorNotEqualDefineAssignAddAssignSubAssignMulAssignQuoAssignRemAssignAndAssignOrAssignXorAssignShlAssignShrAssignAndNotAssignIncDecPlusMinusAddrDerefBitCompArrowEllipsisNotTildeCommaSemicolonColonParenBlockBracketBlockBraceBlockBreakCaseChanConstContinueDefaultDeferElseFallthroughForFuncGoGotoIfImportInterfaceMapPackageRangeReturnSelectStructSwitchTypeVarCallCallXCompositeEqualSetGrowIndexJumpFalseJumpSetFalseJumpSetTrueLabelNew"
 
-var _Token_index = [...]uint16{0, 7, 14, 19, 23, 28, 32, 35, 41, 44, 47, 50, 53, 56, 59, 61, 64, 67, 70, 76, 82, 87, 94, 106, 110, 114, 123, 126, 134, 140, 146, 155, 164, 173, 182, 191, 200, 208, 217, 226, 235, 247, 250, 253, 257, 262, 266, 271, 278, 283, 291, 294, 299, 304, 313, 318, 328, 340, 350, 355, 359, 363, 368, 376, 383, 388, 392, 403, 406, 410, 412, 416, 418, 424, 433, 436, 443, 448, 454, 460, 466, 472, 476, 479, 483, 488, 496, 500, 505, 514, 526, 537, 542, 545}
+var _Token_index = [...]uint16{0, 7, 14, 19, 23, 28, 32, 35, 41, 44, 47, 50, 53, 56, 59, 61, 64, 67, 70, 76, 82, 87, 94, 106, 110, 114, 123, 126, 134, 140, 146, 155, 164, 173, 182, 191, 200, 208, 217, 226, 235, 247, 250, 253, 257, 262, 266, 271, 278, 283, 291, 294, 299, 304, 313, 318, 328, 340, 350, 355, 359, 363, 368, 376, 383, 388, 392, 403, 406, 410, 412, 416, 418, 424, 433, 436, 443, 448, 454, 460, 466, 472, 476, 479, 483, 488, 497, 505, 509, 514, 523, 535, 546, 551, 554}
 
 func (i Token) String() string {
 	if i < 0 || i >= Token(len(_Token_index)-1) {

--- a/parser/compiler.go
+++ b/parser/compiler.go
@@ -134,6 +134,9 @@ func (c *Compiler) Codegen(tokens Tokens) (err error) {
 			}
 			emit(int64(t.Pos), vm.CallX, int64(t.Beg))
 
+		case lang.Composite:
+			log.Println("COMPOSITE")
+
 		case lang.Grow:
 			emit(int64(t.Pos), vm.Grow, int64(t.Beg))
 

--- a/parser/decl.go
+++ b/parser/decl.go
@@ -280,10 +280,11 @@ func (p *Parser) parseTypeLine(in Tokens) (out Tokens, err error) {
 	if isAlias {
 		toks = toks[1:]
 	}
-	typ, err := p.ParseTypeExpr(toks)
+	typ, err := p.parseTypeExpr(toks)
 	if err != nil {
 		return out, err
 	}
+	typ.Name = in[0].Str
 	p.addSym(unsetAddr, in[0].Str, vm.NewValue(typ), symType, typ, p.funcScope != "")
 	return out, err
 }

--- a/parser/interpreter_test.go
+++ b/parser/interpreter_test.go
@@ -255,3 +255,11 @@ func TestImport(t *testing.T) {
 		{src: `import . "fmt"; Println(4)`, res: "<nil>"},
 	})
 }
+
+func TestComposite(t *testing.T) {
+	run(t, []etest{
+		{src: "type T struct{}; t := T{}; t", res: "{}"},
+		{src: "t := struct{}{}; t", res: "{}"},
+		//		{src: "type T struct{N int}; t := T{2}; t", res: "{2}"},
+	})
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -74,7 +74,7 @@ func (p *Parser) parseStmt(in Tokens) (out Tokens, err error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
-	log.Println("ParseStmt in:", in)
+	log.Println("parseStmt in:", in)
 	switch t := in[0]; t.Tok {
 	case lang.Break:
 		return p.parseBreak(in)
@@ -249,7 +249,7 @@ func (p *Parser) parseFunc(in Tokens) (out Tokens, err error) {
 	if bi < 0 {
 		return out, fmt.Errorf("no function body")
 	}
-	typ, err := p.ParseTypeExpr(in[:bi])
+	typ, err := p.parseTypeExpr(in[:bi])
 	if err != nil {
 		return out, err
 	}

--- a/vm/type.go
+++ b/vm/type.go
@@ -10,10 +10,19 @@ type Type struct {
 	Rtype reflect.Type
 }
 
+func (t *Type) String() string {
+	if t.Name != "" {
+		return t.Name
+	}
+	return t.Rtype.String()
+}
+
+// Elem returns a type's element type.
 func (t *Type) Elem() *Type {
 	return &Type{Rtype: t.Rtype.Elem()}
 }
 
+// Out returns the type's i'th output parameter.
 func (t *Type) Out(i int) *Type {
 	return &Type{Rtype: t.Rtype.Out(i)}
 }
@@ -43,18 +52,22 @@ func ValueOf(v any) Value {
 	return Value{Data: reflect.ValueOf(v)}
 }
 
+// PointerTo returns the pointer type with element t.
 func PointerTo(t *Type) *Type {
 	return &Type{Rtype: reflect.PointerTo(t.Rtype)}
 }
 
-func ArrayOf(size int, t *Type) *Type {
-	return &Type{Rtype: reflect.ArrayOf(size, t.Rtype)}
+// ArrayOf returns the array type with the given length and element type.
+func ArrayOf(length int, t *Type) *Type {
+	return &Type{Rtype: reflect.ArrayOf(length, t.Rtype)}
 }
 
+// SliceOf returns the slice type with the given element type.
 func SliceOf(t *Type) *Type {
 	return &Type{Rtype: reflect.SliceOf(t.Rtype)}
 }
 
+// FuncOf returns the function type with the given argument and result types.
 func FuncOf(arg, ret []*Type, variadic bool) *Type {
 	a := make([]reflect.Type, len(arg))
 	for i, e := range arg {
@@ -67,6 +80,7 @@ func FuncOf(arg, ret []*Type, variadic bool) *Type {
 	return &Type{Rtype: reflect.FuncOf(a, r, variadic)}
 }
 
+// StructOf returns the struct type with the given field types.
 func StructOf(fields []*Type) *Type {
 	rf := make([]reflect.StructField, len(fields))
 	for i, f := range fields {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -1,3 +1,4 @@
+// Package vm implement a stack based virtual machine.
 package vm
 
 import (
@@ -85,6 +86,7 @@ var strop = [...]string{ // for VM tracing.
 	Vassign:      "Vassign",
 }
 
+// Code represents the virtual machine byte code.
 type Code [][]int64
 
 // Machine represents a virtual machine.
@@ -256,19 +258,24 @@ func (m *Machine) Run() (err error) {
 	}
 }
 
+// PushCode adds instructions to the machine code.
 func (m *Machine) PushCode(code ...[]int64) (p int) {
 	p = len(m.code)
 	m.code = append(m.code, code...)
 	return p
 }
 
+// SetIP sets the value of machine instruction pointer to given index.
 func (m *Machine) SetIP(ip int) { m.ip = ip }
+
+// Push pushes data values on top of machine memory stack.
 func (m *Machine) Push(v ...Value) (l int) {
 	l = len(m.mem)
 	m.mem = append(m.mem, v...)
 	return l
 }
 
+// Pop removes and returns the value on the top of machine stack.
 func (m *Machine) Pop() (v Value) {
 	l := len(m.mem) - 1
 	v = m.mem[l]
@@ -276,6 +283,7 @@ func (m *Machine) Pop() (v Value) {
 	return v
 }
 
+// Top returns (but not remove)  the value on the top of machine stack.
 func (m *Machine) Top() (v Value) {
 	if l := len(m.mem); l > 0 {
 		v = m.mem[l-1]
@@ -283,12 +291,14 @@ func (m *Machine) Top() (v Value) {
 	return v
 }
 
+// PopExit removes the last machine code instruction if is Exit.
 func (m *Machine) PopExit() {
 	if l := len(m.code); l > 0 && m.code[l-1][1] == Exit {
 		m.code = m.code[:l-1]
 	}
 }
 
+// CodeString returns the string representation of a machine code instruction.
 func CodeString(op []int64) string {
 	switch len(op) {
 	case 2:
@@ -317,6 +327,7 @@ func slint(a []int64) []int {
 	return r
 }
 
+// Vstring returns the string repreentation of a list of values.
 func Vstring(lv []Value) string {
 	s := "["
 	for _, v := range lv {


### PR DESCRIPTION
A new `Composite` token is created. Literal composite expressions are recognized and partially handled by the parser but not yet by the code generator.

Other cosmetic changes are present.